### PR TITLE
Refactor/remove connectors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,12 @@ function verbosePrint(port, enableGraphiql) {
     }
 }
 
+class TestConnector {
+  public get testString() {
+    return "it works from connector as well!";
+  }
+}
+
 export function main(options: IMainOptions) {
     let app = express();
     app.use(helmet());
@@ -33,11 +39,13 @@ export function main(options: IMainOptions) {
     if ( true === options.enableCors ) {
         app.use(GRAPHQL_ROUTE, cors());
     }
-
+  
+    let testConnector = new TestConnector();
     app.use(GRAPHQL_ROUTE, bodyParser.json(), graphqlExpress({
-        context: {},
+        context: {testConnector},
         schema: Schema,
     }));
+  
     if ( true === options.enableGraphiql ) {
         app.use(GRAPHIQL_ROUTE, graphiqlExpress({
             endpointURL: GRAPHQL_ROUTE,

--- a/src/schema.spec.ts
+++ b/src/schema.spec.ts
@@ -52,8 +52,9 @@ describe("Schema", () => {
         let testQuery = `{
             testStringConnector
         }`;
-
-        return graphql(Schema, testQuery, undefined, {}).then((res) => {
+  
+        const ctx = {testConnector: {testString: 'it works from connector as well!'}};
+        return graphql(Schema, testQuery, undefined, ctx).then((res) => {
             assertNoError(res);
             expect(res.data).toMatchSnapshot();
         });

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -17,16 +17,6 @@ const mainDefs = [`
 `,
 ];
 
-class TestConnector {
-    constructor (private ctx: any) {
-
-    }
-
-    public get testString() {
-        return "it works from connector as well!";
-    }
-}
-
 const resolvers = Object.assign({},
     ...(modules.map((m) => m.resolver).filter((res) => !!res)), {
 });
@@ -34,9 +24,6 @@ const resolvers = Object.assign({},
 const typeDefs = mainDefs.concat(modules.map((m) => m.typeDef).filter((res) => !!res));
 
 const Schema: GraphQLSchema = makeExecutableSchema({
-    connectors: {
-        testConnector: TestConnector,
-    },
     logger: console,
     resolverValidationOptions: {
         requireResolversForNonScalar: false,

--- a/src/schema/modules/query.ts
+++ b/src/schema/modules/query.ts
@@ -15,7 +15,6 @@ export const resolver = {
             return "it Works!";
         },
         testStringConnector(root, args, ctx) {
-          console.log(arguments);
           return ctx.testConnector.testString;
         },
         someType(root, args, ctx) {

--- a/src/schema/modules/query.ts
+++ b/src/schema/modules/query.ts
@@ -15,7 +15,8 @@ export const resolver = {
             return "it Works!";
         },
         testStringConnector(root, args, ctx) {
-            return ctx.connectors.testConnector.testString;
+          console.log(arguments);
+          return ctx.testConnector.testString;
         },
         someType(root, args, ctx) {
             return { testFloat: 303.0303, testInt: 666 };


### PR DESCRIPTION
I've removed the connectors from the apolloExpress constructor as it is deprecated. 
Now the connector, or in the future model, will be passed into the context object directly.
